### PR TITLE
chore: add open-source governance docs and CI workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,47 @@
+name: Bug report
+description: Report a bug to help us improve
+labels: ["bug"]
+body:
+  - type: input
+    id: version
+    attributes:
+      label: Package version
+      description: Which version of Umbraco.Community.LinkedPages are you using?
+      placeholder: e.g. 18.0.0
+    validations:
+      required: true
+  - type: input
+    id: umbraco-version
+    attributes:
+      label: Umbraco version
+      placeholder: e.g. 18.0.0
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the bug
+      description: A clear and concise description of what the bug is.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Steps to reproduce the behavior.
+      placeholder: |
+        1. Go to '...'
+        2. Click on '...'
+        3. See error
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What you expected to happen.
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Screenshots, logs, or other context about the problem.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Discussion / Support
+    url: https://our.umbraco.com/packages/backoffice-extensions/linked-pages/linked-pages-feedback/
+    about: Please ask general questions and get support on the Umbraco community forum.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,24 @@
+name: Feature request
+description: Suggest an idea for this project
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Is your feature request related to a problem?
+      description: A clear and concise description of what the problem is.
+  - type: textarea
+    id: solution
+    attributes:
+      label: Describe the solution you'd like
+      description: A clear and concise description of what you want to happen.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Describe alternatives you've considered
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+## Description
+
+<!-- Describe what this PR changes and why. -->
+
+## Related issue(s)
+
+<!-- e.g. Fixes #123 -->
+
+## Checklist
+
+- [ ] The solution builds successfully (`dotnet build`)
+- [ ] I have updated documentation where relevant
+- [ ] I have tested my changes manually

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,36 @@
+name: Build
+
+on:
+  push:
+    branches: [ "v18/main" ]
+  pull_request:
+    branches: [ "v18/main" ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Restore
+        run: dotnet restore src/Umbraco.Community.LinkedPages/Umbraco.Community.LinkedPages.csproj
+
+      - name: Build
+        run: dotnet build src/Umbraco.Community.LinkedPages/Umbraco.Community.LinkedPages.csproj --configuration Release --no-restore
+
+      - name: Pack
+        run: dotnet pack src/Umbraco.Community.LinkedPages/Umbraco.Community.LinkedPages.csproj --configuration Release --no-build --output ./artifacts
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: nuget-package
+          path: ./artifacts/*.nupkg

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,75 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- Standard open-source repository documentation (LICENSE, CONTRIBUTING,
+  CODE_OF_CONDUCT, SECURITY, issue/PR templates, CI workflow).
+
+## [18.0.0] - 2026-06-30
+
+### Added
+
+- Updated package to support Umbraco 18.
+
+## [17.0.0] - 2026-06-15
+
+### Added
+
+- Created a version 17 compatible version of Linked Pages.
+
+### Changed
+
+- Visual improvements to the Linked Pages backoffice UI.
+
+## [10.0.3] - 2024-01-17
+
+### Fixed
+
+- Ensured a sensible default is used when the relation type config is blank.
+- Ensured the relation type is read correctly from config.
+
+### Changed
+
+- Bumped the maximum supported Umbraco version.
+- Removed unused gulp scripts (not needed for the RCL-based package).
+- Updated `umbraco-marketplace.json`.
+- Moved the repository.
+
+## [10.0.0] - 2022-12-02
+
+### Added
+
+- Stable v10/v11 release of Linked Pages.
+- Shared strings moved to a constants class to avoid typos.
+- Use of a constant for the admin group name.
+
+### Changed
+
+- Renamed `Componet` to `Component`.
+- Updated comments to note the correct target framework.
+
+### Security
+
+- Bumped `Microsoft.Owin` from 4.0.1 to 4.1.1 in `LinkedPages.EightSite`.
+- Bumped `Newtonsoft.Json` from 12.0.1 to 13.0.1 in `LinkedPages.EightSite`.
+- Bumped `SharpZipLib` from 0.86.0 to 1.3.3 in `LinkedPages.EightSite`.
+
+## [9.0.0-beta001] - 2021-07-13
+
+### Added
+
+- Initial beta release of Linked Pages for Umbraco v9.
+
+[Latest]: https://github.com/Jumoo/Our.Umbraco.LinkedPages/compare/release/18.0.0...v18/main
+[18.0.0]: https://github.com/Jumoo/Our.Umbraco.LinkedPages/compare/release/17.0.0...release/18.0.0
+[17.0.0]: https://github.com/Jumoo/Our.Umbraco.LinkedPages/compare/release/10.0.3...release/17.0.0
+[10.0.3]: https://github.com/Jumoo/Our.Umbraco.LinkedPages/compare/release/10.0.0...release/10.0.3
+[10.0.0]: https://github.com/Jumoo/Our.Umbraco.LinkedPages/compare/9.0.0-beta001...release/10.0.0
+[9.0.0-beta001]: https://github.com/Jumoo/Our.Umbraco.LinkedPages/releases/tag/9.0.0-beta001

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,58 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Project maintainers are responsible for clarifying and enforcing our standards
+of acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies
+when an individual is officially representing the community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement via the
+repository's issue tracker or by contacting the maintainers directly.
+All complaints will be reviewed and investigated promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org),
+version 2.1, available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,57 @@
+# Contributing to Our.Umbraco.LinkedPages
+
+Thanks for taking the time to contribute! The following is a set of guidelines
+for contributing to this project.
+
+## Code of Conduct
+
+This project and everyone participating in it is governed by the
+[Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to
+uphold this code.
+
+## Reporting Issues
+
+Before creating a bug report, please check the existing
+[issues](https://github.com/Jumoo/Our.Umbraco.LinkedPages/issues) to see if
+the problem has already been reported. When filing an issue, please include:
+
+* The version of Umbraco you are using
+* The version of this package you are using
+* Steps to reproduce the issue
+* What you expected to happen and what actually happened
+
+## Suggesting Enhancements
+
+Feature requests are welcome. Please open an issue describing the enhancement,
+why it would be useful, and any alternative solutions you've considered.
+
+## Pull Requests
+
+1. Fork the repository and create your branch from `v18/main` (or the
+   relevant version branch).
+2. Make your changes, following the existing code style.
+3. Ensure the solution builds successfully (`dotnet build`).
+4. Update documentation (`README.md`) if relevant.
+5. Submit a pull request describing your changes and referencing any related
+   issues.
+
+## Development Setup
+
+The solution is at `src/LinkedPages.slnx` and contains:
+
+* `Umbraco.Community.LinkedPages` - the package project
+* `LinkedPages.Site` - a test Umbraco site used to run/debug the package
+
+The backoffice client lives under
+`src/Umbraco.Community.LinkedPages/Client` and is built with Vite/TypeScript.
+See the `Client` folder for build instructions (`npm install` / `npm run build`).
+
+## Style Guidelines
+
+* Follow the existing coding conventions found in the codebase.
+* Keep pull requests focused on a single change where possible.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the
+[MIT License](LICENSE).

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Jumoo
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![Build](https://github.com/Jumoo/Our.Umbraco.LinkedPages/actions/workflows/build.yml/badge.svg)](https://github.com/Jumoo/Our.Umbraco.LinkedPages/actions/workflows/build.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+
 # Our.Umbraco.LinkedPages
 Context Menu option for managing relations in Umbraco
 
@@ -11,3 +14,17 @@ Add or remove relations directly on a node.
 
 ### Build process
 > This branch is multi-targeting, and will generate a nuget package that works on Umbraco v8 (.netframework) and v9 (.netcore)
+
+## Contributing
+
+Contributions are welcome! Please read [CONTRIBUTING.md](CONTRIBUTING.md) for
+details on our code of conduct and the process for submitting pull requests.
+
+## Security
+
+If you discover a security vulnerability, please see [SECURITY.md](SECURITY.md)
+for how to report it responsibly.
+
+## License
+
+This project is licensed under the [MIT License](LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,29 @@
+# Security Policy
+
+## Supported Versions
+
+Security fixes are generally only applied to the latest released major
+version of this package, matching the currently supported Umbraco versions.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| v18.*   | :white_check_mark: |
+| v17.*   | :white_check_mark: |
+| Older   | :x:                |
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability, please **do not** open a public
+GitHub issue. Instead, report it privately by emailing the maintainers at
+[support@jumoo.co.uk](mailto:support@jumoo.co.uk) or via GitHub's
+[private vulnerability reporting](https://github.com/Jumoo/Our.Umbraco.LinkedPages/security/advisories/new)
+feature.
+
+Please include:
+
+* A description of the vulnerability and its potential impact
+* Steps to reproduce the issue
+* Any relevant logs or proof-of-concept code
+
+We will acknowledge your report as soon as possible and work with you to
+understand and address the issue.


### PR DESCRIPTION
Adds LICENSE, CODE_OF_CONDUCT, CONTRIBUTING, SECURITY, CHANGELOG, issue/PR templates and a CI build workflow. Updates README with badges and links to the new docs.